### PR TITLE
New features: isolated feature sets and exact combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ In your `Cargo.toml`, you can configure the feature combination matrix:
 # This feature is intended for projects with large number of features, sub-sets 
 # of which are completely independent, and thus don’t need cross-play.
 #
-# Other configuration options are still respected.
+# Non-existent features are ignored. Other configuration options are still 
+# respected.
 isolated_feature_sets = [
     ["foo-a", "foo-b", "foo-c"],
     ["bar-a", "bar-b"],
@@ -91,8 +92,9 @@ skip_feature_sets = [ ["foo", "bar"], ]
 denylist = ["default", "full"]
 
 # In the end, always add these exact combinations to the overall feature matrix, 
-# unless one is already present there. These exact combinations are added without 
-# respecting any other configuration options.
+# unless one is already present there.
+#
+# Non-existent features are ignored. Other configuration options are ignored.
 exact_combinations = [
     ["foo-a", "bar-a", "other-a"],
 ]

--- a/README.md
+++ b/README.md
@@ -68,30 +68,31 @@ In your `Cargo.toml`, you can configure the feature combination matrix:
 
 ```toml
 [package.metadata.cargo-feature-combinations]
-# Exclude groupings of features that are incompatible or do not make sense
-skip_feature_sets = [ ["foo", "bar"], ]
-
-# Exclude features from the feature combination matrix
-denylist = ["default", "full"]
-
-# Instead of treating all project features as a unified set, split all features 
-# into these isolated sets. Build a sub-matrix for each isolated set, then merge 
-# sub-matrices into the overall feature matrix. If any two isolated sets produce 
-# an identical feature combination, such combination will be included in the 
-# overall matrix only once.
+# When at least one isolated feature set is configured, stop taking all project 
+# features as a whole, and instead take them in these isolated sets. Build a 
+# sub-matrix for each isolated set, then merge sub-matrices into the overall 
+# feature matrix. If any two isolated sets produce an identical feature 
+# combination, such combination will be included in the overall matrix only once.
 #
-# This is intended for projects with large number of features, sub-sets of which 
-# are completely independent, and thus don’t need cross-combination.
+# This feature is intended for projects with large number of features, sub-sets 
+# of which are completely independent, and thus don’t need cross-play.
 #
-# The other configuration options are still honored.
+# Other configuration options are still respected.
 isolated_feature_sets = [
     ["foo-a", "foo-b", "foo-c"],
     ["bar-a", "bar-b"],
     ["other-a", "other-b", "other-c"],
 ]
 
-# Always add these exact combinations to the overall feature matrix, unless one 
-# is already present there.
+# Exclude groupings of features that are incompatible or do not make sense
+skip_feature_sets = [ ["foo", "bar"], ]
+
+# Exclude features from the feature combination matrix
+denylist = ["default", "full"]
+
+# In the end, always add these exact combinations to the overall feature matrix, 
+# unless one is already present there. These exact combinations are added without 
+# respecting any other configuration options.
 exact_combinations = [
     ["foo-a", "bar-a", "other-a"],
 ]

--- a/README.md
+++ b/README.md
@@ -73,6 +73,28 @@ skip_feature_sets = [ ["foo", "bar"], ]
 
 # Exclude features from the feature combination matrix
 denylist = ["default", "full"]
+
+# Instead of treating all project features as a unified set, split all features 
+# into these isolated sets. Build a sub-matrix for each isolated set, then merge 
+# sub-matrices into the overall feature matrix. If any two isolated sets produce 
+# an identical feature combination, such combination will be included in the 
+# overall matrix only once.
+#
+# This is intended for projects with large number of features, sub-sets of which 
+# are completely independent, and thus don’t need cross-combination.
+#
+# The other configuration options are still honored.
+isolated_feature_sets = [
+    ["foo-a", "foo-b", "foo-c"],
+    ["bar-a", "bar-b"],
+    ["other-a", "other-b", "other-c"],
+]
+
+# Always add these exact combinations to the overall feature matrix, unless one 
+# is already present there.
+exact_combinations = [
+    ["foo-a", "bar-a", "other-a"],
+]
 ```
 
 ### Usage with github-actions

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,9 +4,13 @@ use std::collections::{HashMap, HashSet};
 #[derive(Serialize, Deserialize, Default, Debug)]
 pub struct Config {
     #[serde(default)]
+    pub isolated_feature_sets: Vec<HashSet<String>>,
+    #[serde(default)]
     pub skip_feature_sets: Vec<HashSet<String>>,
     #[serde(default)]
     pub denylist: HashSet<String>,
+    #[serde(default)]
+    pub exact_combinations: Vec<HashSet<String>>,
     #[serde(default)]
     pub exclude_packages: Vec<String>,
     #[serde(default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ impl Package for cargo_metadata::Package {
         let mut filtered_powerset = base_powerset
             .into_iter()
             .filter(|feature_set| {
-                config.skip_feature_sets.iter().any(|skip_set| { // remove feature sets containing any of the skip sets
+                !config.skip_feature_sets.iter().any(|skip_set| { // remove feature sets containing any of the skip sets
                     skip_set
                         .iter()
                         .all(|skip_feature| feature_set.contains(skip_feature)) // skip set is contained when all its features are contained

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,6 +480,28 @@ skip_feature_sets = [ ["foo", "bar"], ]
 
 # Exclude features from the feature combination matrix
 denylist = ["default", "full"]
+
+# Instead of treating all project features as a unified set, split all features
+# into these isolated sets. Build a sub-matrix for each isolated set, then merge
+# sub-matrices into the overall feature matrix. If any two isolated sets produce
+# an identical feature combination, such combination will be included in the
+# overall matrix only once.
+#
+# This is intended for projects with large number of features, sub-sets of which
+# are completely independent, and thus don’t need cross-combination.
+#
+# The other configuration options are still honored.
+isolated_feature_sets = [
+    ["foo-a", "foo-b", "foo-c"],
+    ["bar-a", "bar-b"],
+    ["other-a", "other-b", "other-c"],
+]
+
+# Always add these exact combinations to the overall feature matrix, unless one
+# is already present there.
+exact_combinations = [
+    ["foo-a", "bar-a", "other-a"],
+]
 ```
 
 For more information, see 'https://github.com/romnn/cargo-feature-combinations'.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -475,30 +475,31 @@ For example:
 
 ```toml
 [package.metadata.cargo-feature-combinations]
-# Exclude groupings of features that are incompatible or do not make sense
-skip_feature_sets = [ ["foo", "bar"], ]
-
-# Exclude features from the feature combination matrix
-denylist = ["default", "full"]
-
-# Instead of treating all project features as a unified set, split all features
-# into these isolated sets. Build a sub-matrix for each isolated set, then merge
-# sub-matrices into the overall feature matrix. If any two isolated sets produce
-# an identical feature combination, such combination will be included in the
-# overall matrix only once.
+# When at least one isolated feature set is configured, stop taking all project
+# features as a whole, and instead take them in these isolated sets. Build a
+# sub-matrix for each isolated set, then merge sub-matrices into the overall
+# feature matrix. If any two isolated sets produce an identical feature
+# combination, such combination will be included in the overall matrix only once.
 #
-# This is intended for projects with large number of features, sub-sets of which
-# are completely independent, and thus don’t need cross-combination.
+# This feature is intended for projects with large number of features, sub-sets
+# of which are completely independent, and thus don’t need cross-play.
 #
-# The other configuration options are still honored.
+# Other configuration options are still respected.
 isolated_feature_sets = [
     ["foo-a", "foo-b", "foo-c"],
     ["bar-a", "bar-b"],
     ["other-a", "other-b", "other-c"],
 ]
 
-# Always add these exact combinations to the overall feature matrix, unless one
-# is already present there.
+# Exclude groupings of features that are incompatible or do not make sense
+skip_feature_sets = [ ["foo", "bar"], ]
+
+# Exclude features from the feature combination matrix
+denylist = ["default", "full"]
+
+# In the end, always add these exact combinations to the overall feature matrix,
+# unless one is already present there. These exact combinations are added without
+# respecting any other configuration options.
 exact_combinations = [
     ["foo-a", "bar-a", "other-a"],
 ]


### PR DESCRIPTION
I am developing a large library crate with a lot of planned features.

When the feature count grows large, running commands against **all** feature combinations becomes impractical. The `skip_feature_sets` configuration option might help, but in some cases it is not expressive or readable enough.

Suppose there is a framework-style crate. It has 5 features related to database, 3 features related to logging, 4 features related to messaging. These three groups of features are completely independent of each other (as ensured in the code). As the code author, I want to test all feature combinations in the database group, all feature combinations in the logging group, and all feature combinations in the messaging group. But I don’t want to mix these feature groups (as it would create an enormous amount of permutations).

This PR attempts to solve such issue by adding two new features:

- **Isolated feature sets** allow to define isolated groups of features for generating permutations.
- **Exact combinations** allow to explicitly define which particular feature combinations need to be included.

Both features do not break existing logic: if the user doesn’t add the new configuration options, the old ones work the same way.