### PR TITLE
add `--only-packages-with-lib-target` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ OPTIONS:
     --silent                Hide cargo output and only show summary
     --fail-fast             Fail fast on the first bad feature combination
     --exclude-package       Exclude a package from feature combinations 
+    --only-packages-with-lib-target
+                            Only consider packages with a library target
     --errors-only           Allow all warnings, show errors only (-Awarnings)
     --pedantic              Treat warnings like errors in summary and
                             when using --fail-fast


### PR DESCRIPTION
Adds a flag `--only-packages-with-lib-target` that retains only packages with a library target.

This is useful when wanting to run doc-tests on all combinations of features, since doc-tests apparently do not work with binary-only packages.